### PR TITLE
PR off of coldnew/awesome-emacs add-emacs-icon branch

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,13 @@
-#+HTML: <a href="https://github.com/emacs-tw/awesome-emacs"><img src="https://www.gnu.org/software/emacs/images/emacs.png" alt="Emacs Logo" width="80" height="80" align="right"></a>
+#+HTML:<div align=center>
+
+#+BEGIN_HTML
+<a href="https://github.com/emacs-tw/awesome-emacs"><img alt="Emacs Logo" width="240" height="240" src="https://upload.wikimedia.org/wikipedia/commons/0/08/EmacsIcon.svg"></a>
+#+END_HTML
+
 * Awesome Emacs
-[[https://github.com/sindresorhus/awesome][https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg]] [[https://travis-ci.org/emacs-tw/awesome-emacs][file:https://api.travis-ci.org/emacs-tw/awesome-emacs.svg?branch=master]]
+[[https://github.com/sindresorhus/awesome][https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg]] [[https://travis-ci.org/emacs-tw/awesome-emacs][file:https://api.travis-ci.org/emacs-tw/awesome-emacs.svg?branch=master]] [[https://unlicense.org][https://upload.wikimedia.org/wikipedia/commons/e/ee/Unlicense_Blue_Badge.svg]]
+
+#+HTML:</div>
 
 Welcome to Awesome Emacs, a community driven list of useful Emacs packages, utilities and libraries. Most of the following packages are available in [[https://github.com/melpa/melpa][MELPA]]. We recommend installing packages with it.
 

--- a/README.org
+++ b/README.org
@@ -1,8 +1,4 @@
-#+HTML:<div align=center>
-
-#+BEGIN_HTML
-<a href="https://github.com/emacs-tw/awesome-emacs"><img alt="Emacs Logo" width="240" height="240" src="https://upload.wikimedia.org/wikipedia/commons/0/08/EmacsIcon.svg"></a>
-#+END_HTML
+#+HTML:<div align=center><a href="https://github.com/emacs-tw/awesome-emacs"><img alt="Emacs Logo" width="240" height="240" src="https://upload.wikimedia.org/wikipedia/commons/0/08/EmacsIcon.svg"></a>
 
 * Awesome Emacs
 [[https://github.com/sindresorhus/awesome][https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg]] [[https://travis-ci.org/emacs-tw/awesome-emacs][file:https://api.travis-ci.org/emacs-tw/awesome-emacs.svg?branch=master]] [[https://unlicense.org][https://upload.wikimedia.org/wikipedia/commons/e/ee/Unlicense_Blue_Badge.svg]]


### PR DESCRIPTION
Hi @coldnew 

Fantastic idea to put in the emacs logo icon.

Was contemplating your code, then looked at the README.md code from https://github.com/ianpan870102/tron-legacy-emacs-theme . Had to translate the code from markdown to org mode .

Here's a PR with some of my thoughts:
- why not use svg rather than png, easier to do arbitrary resizes and the images are more crisp
- make the image larger
- the image would look better if it was centered.
  - If the image is centered, the Project Title and the buttons should be centered as well
- with the image being centered, having two buttons (the awesome list, and travis button) looks...unbalanced. I added a third button with the license in it. (the tron legacy emacs theme md file has three buttons -- I thought it looked more balanced with regards to centering an image and buttons vs an image, title, and two buttons)

My WIP branch was at: https://github.com/agsdot/awesome-emacs/tree/logoBranch . I did some WIP work here before I git squashed the commits into https://github.com/agsdot/awesome-emacs/tree/add-emacs-icon branch. There are some notes on the git log there for org-mode formatting.